### PR TITLE
支持cri直接使用镜像仓库mirror的能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,79 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 ```
+### 3. 配置常见仓库的镜像加速
+#### 3.1 配置  
+Containerd 较简单，它支持任意 `registry` 的 `mirror`，只需要修改配置文件 `/etc/containerd/config.toml`，添加如下的配置：  
+```yaml
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://xxxx.xx.com"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+          endpoint = ["https://xxxx.xx.com"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
+          endpoint = ["https://xxxx.xx.com"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
+          endpoint = ["https://xxxx.xx.com"]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
+          endpoint = ["https://xxxx.xx.com"]
+```
+`Podman` 同样支持任意 `registry` 的 `mirror`，修改配置文件 `/etc/containers/registries.conf`，添加配置：  
+```yaml
+unqualified-search-registries = ['docker.io', 'k8s.gcr.io', 'gcr.io', 'ghcr.io', 'quay.io']
+
+[[registry]]
+prefix = "docker.io"
+insecure = true
+location = "registry-1.docker.io"
+
+[[registry.mirror]]
+location = "https://xxxx.onrender.com"
+
+[[registry]]
+prefix = "k8s.gcr.io"
+insecure = true
+location = "k8s.gcr.io"
+
+[[registry.mirror]]
+location = "https://xxxx.onrender.com"
+
+[[registry]]
+prefix = "gcr.io"
+insecure = true
+location = "gcr.io"
+
+[[registry.mirror]]
+location = "https://xxxx.onrender.com"
+
+[[registry]]
+prefix = "ghcr.io"
+insecure = true
+location = "ghcr.io"
+
+[[registry.mirror]]
+location = "https://xxxx.onrender.com"
+
+[[registry]]
+prefix = "quay.io"
+insecure = true
+location = "quay.io"
+
+[[registry.mirror]]
+location = "https://xxxx.onrender.com"
+
+```
+
+#### 3.3 使用
+对于以上配置，k8s在使用的时候，就可以直接`pull`外部无法pull的镜像了 
+ 手动可以直接`pull` 配置了`mirror`的仓库  
+ `crictl pull registry.k8s.io/kube-proxy:v1.28.4`
+ `docker  pull nginx:1.21`
+
+
+
+
+
 
 ## 变量说明
 | 变量名 | 示例 | 必填 | 备注 | 


### PR DESCRIPTION
该更新提供了`cri`组件配置`mirror`后，直接访问外部镜像的能力

即，只需要配置`cri`的`mirror`后， 我们就就愉快的`pull`所有外部的镜像 了，，让用户忘记无法pull镜像的烦恼


配置好后
你可以愉快的pull所有镜像,,docker.io/grc.io/registry.k8s.io/  等等~

