### PR TITLE
Fix 400 Error Missing x-amz-content-sha256

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -338,6 +338,11 @@ export default {
 			parameter.headers.Authorization = getReqHeader("Authorization");
 		}
 
+		// 添加可能存在字段x-amz-content-sha256
+		if (request.headers.has("x-amz-content-sha256")) {
+			parameter.headers.Authorization = getReqHeader("x-amz-content-sha256");
+		}
+
 		// 发起请求并处理响应
 		let original_response = await fetch(new Request(url, request), parameter);
 		let original_response_clone = original_response.clone();


### PR DESCRIPTION
error parsing HTTP 400 response body: invalid character '<' looking for beginning of value: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>InvalidRequest</Code><Message>Missing x-amz-content-sha256</Message></Error>"

An exception occurred when accessing the v2 interface to pull the image layer. After investigation, it was found that the request header was incomplete and has been supplemented.

The image where this problem occurs is mysql8.0